### PR TITLE
Update samba to allow running on garm

### DIFF
--- a/dc/Dockerfile
+++ b/dc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ADD krb5.seed /krb5.seed
 RUN apt-get update && \

--- a/dc/init-config.sh
+++ b/dc/init-config.sh
@@ -4,7 +4,7 @@ set -o errexit -o nounset -o pipefail
 [ "${DEBUG:-false}" == true ] && set -x
 
 mv /etc/samba/smb.conf /etc/samba/smb.conf.orig
-samba-tool domain provision --domain=DOMAIN --use-rfc2307 --realm=DOMAIN.TEST --adminpass=passwOrd1
+samba-tool domain provision --domain=DOMAIN --use-rfc2307 --realm=DOMAIN.TEST --adminpass=passwOrd1 --option="acl_xattr:security_acl_name = user.NTACL"
 cp /var/lib/samba/private/krb5.conf /etc/ 
 
 service smbd stop


### PR DESCRIPTION
We need to use samba 4.18 to change the NT ACL default location (see https://wiki.samba.org/index.php/Samba_Features_added/changed#New_option_to_change_the_NT_ACL_default_location). Therefore we use ubuntu 24.04 as base image, as samba 4.18 is already included.

This allows us remove the restriction to run on GitHub hosted runners only and also use the garm runners. A test run can be found at https://github.com/nextcloud/server/actions/runs/9945945714/job/27475372220.
Corresponding test PR on server: https://github.com/nextcloud/server/pull/46548