### PR TITLE
fix(ci): Correctly run tests again

### DIFF
--- a/apache-fpm-gssapi/000-default.conf
+++ b/apache-fpm-gssapi/000-default.conf
@@ -2,15 +2,15 @@
         ServerAdmin webmaster@localhost
         DocumentRoot /var/www/html
 
-		Alias /kerb /var/www/html
-        <Directory /var/www/html>
+	Alias /kerb /var/www/html
+        <Location />
                 AuthType GSSAPI
                 AuthName "GSSAPI Single Sign On Login"
                 GssapiAcceptorName HTTP@httpd.domain.test
                 GssapiCredStore keytab:/shared/httpd.keytab
                 GssapiDelegCcacheDir /tmp
                 Require valid-user
-        </Directory>
+        </Location>
 
         ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/var/www/html/$1
 

--- a/apache-gssapi/000-default.conf
+++ b/apache-gssapi/000-default.conf
@@ -2,15 +2,15 @@
         ServerAdmin webmaster@localhost
         DocumentRoot /var/www/html
 
-		Alias /kerb /var/www/html
-        <Directory /var/www/html>
+	Alias /kerb /var/www/html
+        <Location />
                 AuthType GSSAPI
                 AuthName "GSSAPI Single Sign On Login"
                 GssapiAcceptorName HTTP@httpd.domain.test
                 GssapiCredStore keytab:/shared/httpd.keytab
                 GssapiDelegCcacheDir /tmp
                 Require valid-user
-        </Directory>
+        </Location>
 
         ErrorLog /shared/apache-error.log
         CustomLog /shared/apache-access.log combined

--- a/apache/000-default.conf
+++ b/apache/000-default.conf
@@ -2,8 +2,8 @@
         ServerAdmin webmaster@localhost
         DocumentRoot /var/www/html
 
-		Alias /kerb /var/www/html
-        <Directory /var/www/html>
+	Alias /kerb /var/www/html
+        <Location />
                 AuthType Kerberos
                 AuthName "Kerberos authenticated intranet"
                 KrbAuthRealms DOMAIN.TEST
@@ -13,7 +13,7 @@
                 KrbMethodK5Passwd On
                 KrbSaveCredentials On
                 require valid-user
-        </Directory>
+        </Location>
 
         ErrorLog ${APACHE_LOG_DIR}/error.log
         CustomLog ${APACHE_LOG_DIR}/access.log combined

--- a/nginx-fpm-gssapi/nginx.conf
+++ b/nginx-fpm-gssapi/nginx.conf
@@ -33,30 +33,21 @@ http {
 
         autoindex on;
 
-		location /kerb/ {
+		location ^~ /kerb/ {
 			alias /var/www/html/;
-			auth_gss on;
-			auth_gss_keytab /shared/httpd.keytab;
-
-			auth_gss_service_ccache /tmp;
-			auth_gss_delegate_credentials on;
-			auth_gss_constrained_delegation on;
-
-			location ~ \.php(?:$|/) {
-				fastcgi_split_path_info ^(.+\.php)(/.+)$;
-				include fastcgi_params;
-				fastcgi_param SCRIPT_FILENAME $request_filename;
-				fastcgi_param PATH_INFO $fastcgi_path_info;
-				fastcgi_param KRB5CCNAME $krb5_cc_name;
-				fastcgi_pass php-handler;
-				fastcgi_read_timeout 600;
-			}
 		}
 
         root /var/www/html;
 
         client_max_body_size 10M;
         fastcgi_buffers 64 4K;
+
+        auth_gss on;
+        auth_gss_keytab /shared/httpd.keytab;
+
+        auth_gss_service_ccache /tmp;
+        auth_gss_delegate_credentials on;
+        auth_gss_constrained_delegation on;        
 
         location ~ \.php(?:$|/) {
             fastcgi_split_path_info ^(.+\.php)(/.+)$;


### PR DESCRIPTION
Seems to be a regression from https://github.com/icewind1991/samba-krb-test/commit/9f64b78b76bd9a75a323bab33f15c618c1d5aeb7, but since the built images were not used (that was fixed in https://github.com/icewind1991/samba-krb-test/commit/2f6a07b9107f15e9504e6ddc99d7251f5f8dcae2) it wasn't catched, as the old images worked.
It's not a perfect fix, but should at. least confirm that it's working correctly. And with new images, we can allow the tests to finally run on garm as well.