### PR TITLE
fix(ci): Use correct URL for tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,7 @@ jobs:
           
           docker ps -a
 
-          LIST=$(./client-cmd.sh $DC_IP curl --negotiate -u testuser@DOMAIN.TEST: --delegation always http://httpd.domain.test/example-sso-kerberos.php)
+          LIST=$(./client-cmd.sh $DC_IP curl --negotiate -u testuser@DOMAIN.TEST: --delegation always http://httpd.domain.test/kerb/example-sso-kerberos.php)
 
           echo $LIST
 

--- a/apache-fpm-gssapi/000-default.conf
+++ b/apache-fpm-gssapi/000-default.conf
@@ -2,7 +2,7 @@
         ServerAdmin webmaster@localhost
         DocumentRoot /var/www/html
 
-		Alias /kerb /var/www/html
+	Alias /kerb /var/www/html
         <Directory /var/www/html>
                 AuthType GSSAPI
                 AuthName "GSSAPI Single Sign On Login"
@@ -12,7 +12,9 @@
                 Require valid-user
         </Directory>
 
-        ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/var/www/html/$1
+        <FilesMatch \.php$>
+                SetHandler "proxy:fcgi://127.0.0.1:9000"
+        </FilesMatch>
 
         ErrorLog /shared/apache-error.log
         CustomLog /shared/apache-access.log combined

--- a/apache-gssapi/000-default.conf
+++ b/apache-gssapi/000-default.conf
@@ -2,7 +2,7 @@
         ServerAdmin webmaster@localhost
         DocumentRoot /var/www/html
 
-		Alias /kerb /var/www/html
+	Alias /kerb /var/www/html
         <Directory /var/www/html>
                 AuthType GSSAPI
                 AuthName "GSSAPI Single Sign On Login"

--- a/apache/000-default.conf
+++ b/apache/000-default.conf
@@ -2,7 +2,7 @@
         ServerAdmin webmaster@localhost
         DocumentRoot /var/www/html
 
-		Alias /kerb /var/www/html
+	Alias /kerb /var/www/html
         <Directory /var/www/html>
                 AuthType Kerberos
                 AuthName "Kerberos authenticated intranet"


### PR DESCRIPTION
* Supersedes https://github.com/icewind1991/samba-krb-test/pull/5

The URL was only changed in `run.sh`, but not in the tests.