### PR TITLE
fix(dc): Catch errors in parent script (entrypoint.sh)

### DIFF
--- a/dc/entrypoint.sh
+++ b/dc/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o errexit -o nounset -o pipefail
 /init-config.sh
 
 samba-tool user create httpd-service --random-password


### PR DESCRIPTION
Without this, even though the child script (init-config.sh) already has this handling, the parent (entrypoint) will continue on even if there are errors.

Found while trying to figure out why the *Samba Kerberos SSO* workflow has failing randomly in nextcloud/server recently.