### PR TITLE
fix: Remove race-condition on samba-ad-dc start/restart

### DIFF
--- a/dc/init-config.sh
+++ b/dc/init-config.sh
@@ -9,8 +9,8 @@ cp /var/lib/samba/private/krb5.conf /etc/
 
 service smbd stop
 service nmbd stop
+
 service samba-ad-dc start
-service samba-ad-dc restart
 service samba-ad-dc status
 
 samba-tool domain level show

--- a/nginx-fpm-gssapi/Dockerfile
+++ b/nginx-fpm-gssapi/Dockerfile
@@ -33,7 +33,7 @@ RUN docker-php-ext-configure gd \
 	docker-php-ext-install gd zip pcntl
 
 COPY libnginx-mod-http-auth-spnego_1.18.0-6.1+deb11u3_amd64.deb /usr/local
-RUN dpkg --install /usr/local/libnginx-mod-http-auth-spnego_1.18.0-6.1+deb11u3_amd64.deb
+RUN dpkg --force-depends --install /usr/local/libnginx-mod-http-auth-spnego_1.18.0-6.1+deb11u3_amd64.deb
 RUN sed -i -e "s|clear_env = yes|clear_env = no|" /usr/local/etc/php-fpm.d/docker.conf
 
 ADD nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
It seems that starting and directly restarting `samba-ad-dc` causes a race condition where the port 389 is not yet freed, although we attempt to allocate it already:

```
[2025/04/30 22:59:14.795512,  0] source4/samba/server.c:633(binary_smbd_main)
  samba version 4.19.5-Ubuntu started.
  Copyright Andrew Tridgell and the Samba Team 1992-2023
[2025/04/30 22:59:14.924563,  0] source4/lib/tls/tlscert.c:67(tls_cert_generate)
  Attempting to autogenerate TLS self-signed keys for https for hostname 'KRB.domain.test'
[2025/04/30 22:59:15.878287,  0] source4/samba/server.c:633(binary_smbd_main)
  samba version 4.19.5-Ubuntu started.
  Copyright Andrew Tridgell and the Samba Team 1992-2023
[2025/04/30 22:59:15.974428,  0] source4/lib/tls/tlscert.c:154(tls_cert_generate)
  TLS self-signed keys generated OK
[2025/04/30 22:59:16.509633,  0] source4/samba/service_stream.c:371(stream_setup_socket)
  stream_setup_socket: Failed to listen on :::389 - NT_STATUS_ADDRESS_ALREADY_ASSOCIATED
[2025/04/30 22:59:16.509747,  0] source4/ldap_server/ldap_server.c:[118](https://github.com/nextcloud/server/actions/runs/14765943837/job/41457286732#step:6:119)8(add_socket)
  add_socket: ldapsrv failed to bind to :::389 - NT_STATUS_ADDRESS_ALREADY_ASSOCIATED
[2025/04/30 22:59:16.509814,  0] source4/samba/service_stream.c:371(stream_setup_socket)
  stream_setup_socket: Failed to listen on 0.0.0.0:389 - NT_STATUS_ADDRESS_ALREADY_ASSOCIATED
[2025/04/30 22:59:16.509907,  0] source4/ldap_server/ldap_server.c:1188(add_socket)
  add_socket: ldapsrv failed to bind to 0.0.0.0:389 - NT_STATUS_ADDRESS_ALREADY_ASSOCIATED
[2025/04/30 22:59:16.509956,  0] source4/samba/service_task.c:36(task_server_terminate)
  task_server_terminate: task_server_terminate: [Failed to startup ldap server task]
[2025/04/30 22:59:16.514517,  0] source4/samba/server.c:403(samba_terminate)
  samba_terminate: samba_terminate of samba 138: Failed to startup ldap server task
  ```

Debug run: https://github.com/nextcloud/server/actions/runs/14765943837/job/41457286732#step:6:124

I don't see a reason to do a direct restart here? Was there a reason?